### PR TITLE
Kubernetization

### DIFF
--- a/Dockerfile/zabbix-2.4/retag.sh
+++ b/Dockerfile/zabbix-2.4/retag.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# use on master branche and retag also older tags
+
+tags=()
+for t in `git tag`
+do
+    echo "Deleting tags $t"
+    git tag -d $t
+    git push origin :refs/tags/$t
+    tags=("${tags[@]}" "$t")
+done
+git push origin master
+git push origin --tags
+
+tags=('2.4.0rc1' '2.4.0rc2' '2.4.0rc3' '2.4.1' '2.4.1rc1' '2.4.1rc2' '2.4.2' '2.4.2rc1' '2.4.3' '2.4.3rc1' '2.4.4' '2.4.4rc1' '2.4.5' '2.4.5rc1' '2.4.6' '2.4.7');
+for t in "${tags[@]}"
+do
+    echo "Creating tags $t"
+    git checkout master
+    sed -i -e "s#^  ZABBIX_VERSION=tags.*#  ZABBIX_VERSION=tags/$t \\\#" Dockerfile
+    git add Dockerfile
+    git commit -m "Tag $t"
+    git tag -a $t -m "Tag $t"
+    last=$t        
+done
+git push origin master
+git push origin --tags
+

--- a/Dockerfile/zabbix-db-mariadb/Dockerfile
+++ b/Dockerfile/zabbix-db-mariadb/Dockerfile
@@ -1,23 +1,22 @@
-# docker build --rm=true -t jangaraj/zabbix-db-mariadb .
-
 FROM centos:centos7
 MAINTAINER Jan Garaj info@monitoringartist.com
 
 ENV \
-  DB_max_allowed_packet=64M \	
+  DB_max_allowed_packet=64M \
   DB_query_cache_size=0 \
   DB_query_cache_type=0 \
-  DB_sync_binlog=0 \	
+  DB_sync_binlog=0 \
   DB_innodb_buffer_pool_size=768M \
   DB_innodb_log_file_size=128M \
   DB_innodb_flush_method=O_DIRECT \
   DB_innodb_old_blocks_time=1000 \
-  DB_innodb_flush_log_at_trx_commit=0
+  DB_innodb_flush_log_at_trx_commit=0 \
+  DB_open_files_limit=4096 \
+  DB_max_connections=300
 
 COPY container-files/ /tmp/
 
 RUN \
-    yum update -y && \
     cp /tmp/etc/yum.repos.d/* /etc/yum.repos.d/ && \
     yum install -y epel-release && \
     yum install -y MariaDB-server hostname net-tools pwgen git bind-utils bzip2 && \

--- a/Dockerfile/zabbix-db-mariadb/README.md
+++ b/Dockerfile/zabbix-db-mariadb/README.md
@@ -43,6 +43,8 @@ You can use environmental variables to config MariaDB. Available variables:
 | Variable | Default value |
 | -------- | ------------- |
 |DB_max_allowed_packet | 64M |
+|DB_open_files_limit | 4096 |
+|DB_max_connections | 300 |
 |DB_query_cache_size | 0 |
 |DB_query_cache_type | 0 |
 |DB_sync_binlog | 0 |

--- a/Dockerfile/zabbix-db-mariadb/container-files/etc/my.cnf.d/tuning.cnf
+++ b/Dockerfile/zabbix-db-mariadb/container-files/etc/my.cnf.d/tuning.cnf
@@ -2,6 +2,8 @@
 
 [mysqld]
 max_allowed_packet = DB_max_allowed_packet
+open_files_limit = DB_open_files_limit
+max_connections = DB_max_connections
 
 # Sort buffer is used to perform sorts for some ORDER BY and GROUP BY
 # queries. If sorted data does not fit into the sort buffer, a disk

--- a/Dockerfile/zabbix-db-mariadb/container-files/mariadb-functions.sh
+++ b/Dockerfile/zabbix-db-mariadb/container-files/mariadb-functions.sh
@@ -4,21 +4,17 @@
 # Config DB
 #########################################################
 function config_db() {
-  sed -i 's#DB_max_allowed_packet#'${DB_max_allowed_packet}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_query_cache_size#'${DB_query_cache_size}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_query_cache_type#'${DB_query_cache_type}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_sync_binlog#'${DB_sync_binlog}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_innodb_buffer_pool_size#'${DB_innodb_buffer_pool_size}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_innodb_log_file_size#'${DB_innodb_log_file_size}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_innodb_flush_method#'${DB_innodb_flush_method}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_innodb_old_blocks_time#'${DB_innodb_old_blocks_time}'#g' /etc/my.cnf.d/tuning.cnf
-  sed -i 's#DB_innodb_flush_log_at_trx_commit#'${DB_innodb_flush_log_at_trx_commit}'#g' /etc/my.cnf.d/tuning.cnf
-
+  # ^DB_: /etc/my.cnf.d/tuning.cnf
+  for i in $( set -o posix ; set | grep ^DB_ | sort -rn ); do
+    reg=$(echo ${i} | awk -F'=' '{print $1}')
+    val=$(echo ${i} | awk -F'=' '{print $2}')
+    sed -i "s#=${reg}\$#=${val}#g" /etc/my.cnf.d/tuning.cnf
+  done
+  
   if [ -f /etc/custom-config/mariadb-tuning.cnf ]; then
     cp -f /etc/custom-config/mariadb-tuning.cnf /etc/my.cnf.d/tuning.cnf
   fi
 }
-
 
 #########################################################
 # Check in the loop (every 1s) if the database backend
@@ -39,7 +35,6 @@ function wait_for_db() {
   set -e
 }
 
-
 #########################################################
 # Check in the loop (every 1s) if the database backend
 # service is already available for connections.
@@ -53,7 +48,6 @@ function terminate_db() {
     if tail $ERROR_LOG | grep -s -E "mysqld .+? ended" $ERROR_LOG; then break; else sleep 0.5; fi
   done
 }
-
 
 #########################################################
 # Cals `mysql_install_db` if empty volume is detected.

--- a/Dockerfile/zabbix-db-mariadb/container-files/mariadb-functions.sh
+++ b/Dockerfile/zabbix-db-mariadb/container-files/mariadb-functions.sh
@@ -8,7 +8,7 @@ function config_db() {
   for i in $( set -o posix ; set | grep ^DB_ | sort -rn ); do
     reg=$(echo ${i} | awk -F'=' '{print $1}')
     val=$(echo ${i} | awk -F'=' '{print $2}')
-    sed -i "s#=${reg}\$#=${val}#g" /etc/my.cnf.d/tuning.cnf
+    sed -i "s#${reg}\$#${val}#g" /etc/my.cnf.d/tuning.cnf
   done
   
   if [ -f /etc/custom-config/mariadb-tuning.cnf ]; then


### PR DESCRIPTION
Changes:
- role environment variables: 
  User can start only Zabbix web/Zabbix server/Zabbix agent.
- renaming: 
  It's not only zabbix-server, but almost everything (zabbix-web, zabbix-server, zabbix-agent), so better Docker/folder name is zabbix-X.X.
- simple healthcheck URL:
  /healthcheck/ - it can used for loadbalancer health checks
- SNMP trap processing:
  It's not the best implementation safe trap rate is 5 traps/second.
- zabbix-db-mariadb - env variable for max_connections, ...
- Issue #20 #22 fix

Docker image for the testing https://hub.docker.com/r/monitoringartist/zabbix-2.4/
Zabbix on the Kubernetes implementation https://github.com/monitoringartist/kubernetes-zabbix
