### PR TITLE
Create docker-compose-v2.yml for Compose format v2

### DIFF
--- a/Dockerfile/zabbix-3.0/docker-compose-v2.yml
+++ b/Dockerfile/zabbix-3.0/docker-compose-v2.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+  zabbix-db:
+    image: zabbix/zabbix-db-mariadb
+    volumes:
+      - zabbix-db-storage:/var/lib/mysql
+      - backups:/backups
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - MARIADB_USER=zabbix
+      - MARIADB_PASS=my_password
+  zabbix-server:
+    image: zabbix/zabbix-3.0:latest
+    depends_on:
+      - zabbix-db
+    ports:
+      - "80:80"
+      - "10051:10051"
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+    links:
+      - zabbix-db:zabbix.db
+    environment:
+      - ZS_DBHost=zabbix.db
+      - ZS_DBUser=zabbix
+      - ZS_DBPassword=my_password
+volumes:
+  zabbix-db-storage:
+    driver: local
+  backups:
+    driver: local


### PR DESCRIPTION
Hi! This supports the v2 format of Docker Compose. Because the v1 format supports only Docker Engine 1.10 or less.
So, I wrote new docker-compose.yml that optimizes it in v2 format.

The difference with v1:
- add `volumes` section
- delete `zabbix-db-storage` container ( data containers are unnecessary in v2 )
- add `depends_on` option

The v1 format is still usable. Therefore I added a new file without updating existing yml.
