### PR TITLE
Use proper variable name in bootstrap.sh

### DIFF
--- a/Dockerfile/zabbix-2.4/container-files-zabbix/config/init/bootstrap.sh
+++ b/Dockerfile/zabbix-2.4/container-files-zabbix/config/init/bootstrap.sh
@@ -103,7 +103,7 @@ ZABBIX_SQL_DIR="/usr/local/src/zabbix/database/mysql"
 # load DB config from custom config file if exist
 if [ -f /etc/custom-config/zabbix_server.conf ]; then
   FZS_DBPassword=$(grep ^DBPassword= /etc/custom-config/zabbix_server.conf | awk -F= '{print $2}')
-  if [ ! -z "$VAR" ]; then
+  if [ ! -z "$FZS_DBPassword" ]; then
     export ZS_DBPassword=$FZS_DBPassword
   fi
   FZS_DBUser=$(grep ^DBUser= /etc/custom-config/zabbix_server.conf | awk -F= '{print $2}')


### PR DESCRIPTION
Got error when custom config file exists and failed to start container:

```
/config/init/bootstrap.sh: line 106: VAR: unbound variable
```
