### PR TITLE
Proposal for a complete sandbox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2'
+
+services:
+  zabbix-db:
+    image: monitoringartist/zabbix-db-mariadb
+    environment:
+    - MARIADB_USER=zabbix
+    - MARIADB_PASS=password
+    volumes:
+    - ./containerdata/zabbix-db_mysql:/var/lib/mysql
+    - ./containerdata/zabbix-db_backups:/backups
+    - /etc/localtime:/etc/localtime:ro
+
+  zabbix-xxl:
+    image: monitoringartist/zabbix-xxl:latest
+    environment:
+    - ZS_DBHost=zabbix.db
+    - ZS_DBUser=zabbix
+    - ZS_DBPassword=password
+    volumes:
+    - ./containerdata/zabbix-xxl_backups:/backups
+    - /etc/localtime:/etc/localtime:ro
+    ports:
+    - 10051:10051
+    links:
+    - zabbix-db:zabbix.db
+  zabbix-frontend:
+    image: steveltn/https-portal
+    ports:
+    - 80:80
+    - 443:443
+    links:
+    - zabbix-xxl
+    environment:
+      DOMAINS: 'zabbix -> http://zabbix-xxl'
+      STAGE: 'local'


### PR DESCRIPTION
* Here's a docker-compose file to build a complete sandbox.
* Just install "docker-compose" as described -> https://docs.docker.com/compose/install/
* Make a directory like "myzabbix" and put docker-compose.yml into it.
* Cd into that dir and say: "docker-compose up -d"
* Please note that https frontend is creating new keys. This need's some minutes.
* Feature is that you can change to an fully automated Letsencrypt certificat.
* Please note that Port 10051 is expost to the host ip.
* Backups and Container Database is stored in ./containerdata
* Containerlogs can be viewed with "docker-compose logs -f"