### PR TITLE
Create initial admin account from XXL_ env vars

### DIFF
--- a/Dockerfile/dockbix-xxl/Dockerfile
+++ b/Dockerfile/dockbix-xxl/Dockerfile
@@ -200,6 +200,7 @@ RUN \
   grep 'XXL extensions' /usr/local/src/zabbix/frontends/php/include/menu.inc.php && \
   sed -i "s#'admin': 0},# 'admin': 0, 'xxl': 0},#g" /usr/local/src/zabbix/frontends/php/js/main.js && \
   grep "'xxl': 0}" /usr/local/src/zabbix/frontends/php/js/main.js && \
+  sed -i "s/'Admin','Zabbix','Administrator','5fce1b3e34b520afeffb37ce08c7cd66'/'$XXL_apiuser','Zabbix','Administrator','$(echo -n $XXL_apipass | md5sum | awk '{print $1}')'/" /usr/local/src/zabbix/database/mysql/data.sql && \
   rm -rf /tmp/* && \
   touch /tmp/zabbix_traps.tmp
 

--- a/Dockerfile/dockbix-xxl/Dockerfile
+++ b/Dockerfile/dockbix-xxl/Dockerfile
@@ -200,7 +200,10 @@ RUN \
   grep 'XXL extensions' /usr/local/src/zabbix/frontends/php/include/menu.inc.php && \
   sed -i "s#'admin': 0},# 'admin': 0, 'xxl': 0},#g" /usr/local/src/zabbix/frontends/php/js/main.js && \
   grep "'xxl': 0}" /usr/local/src/zabbix/frontends/php/js/main.js && \
-  sed -i "s/'Admin','Zabbix','Administrator','5fce1b3e34b520afeffb37ce08c7cd66'/'$XXL_apiuser','Zabbix','Administrator','$(echo -n $XXL_apipass | md5sum | awk '{print $1}')'/" /usr/local/src/zabbix/database/mysql/data.sql && \
+  INITIAL_ADMIN_SEARCH="'Admin','Zabbix','Administrator','5fce1b3e34b520afeffb37ce08c7cd66'" && \
+  INITIAL_ADMIN_REPLACE="'$XXL_apiuser','Zabbix','Administrator','$(echo -n $XXL_apipass | md5sum | awk '{print $1}')'" && \
+  grep "$INITIAL_ADMIN_SEARCH" /usr/local/src/zabbix/database/mysql/data.sql && \
+  sed -i "s/$INITIAL_ADMIN_SEARCH/$INITIAL_ADMIN_REPLACE/" /usr/local/src/zabbix/database/mysql/data.sql && \
   rm -rf /tmp/* && \
   touch /tmp/zabbix_traps.tmp
 


### PR DESCRIPTION
# Summary
The intended effect of this PR is to seed the initial admin account
credentials from the XXL_apiuser/XXL_apipass env vars when the
dockbix-xxl container is run with a fresh database endpoint.

# User Story
As a automation engineer,
I want to control the initial Zabbix Super Admin account credentials,
so that deploy time customizations are not dependent on the insecure
default credentials.