### PR TITLE
upgrade to PHP 7.1

### DIFF
--- a/Dockerfile/dockbix-xxl/Dockerfile
+++ b/Dockerfile/dockbix-xxl/Dockerfile
@@ -85,7 +85,7 @@ RUN \
   openssl req -new -key /etc/nginx/ssl/dummy.key -out /etc/nginx/ssl/dummy.csr -subj "/C=GB/L=London/O=Company Ltd/CN=zabbix-docker" && \
   openssl x509 -req -days 3650 -in /etc/nginx/ssl/dummy.csr -signkey /etc/nginx/ssl/dummy.key -out /etc/nginx/ssl/dummy.crt && \
   yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
-  yum install -y --enablerepo=remi-php70 php-fpm \
+  yum install -y --enablerepo=remi-php71 php-fpm \
        php-gd php-bcmath php-ctype php-xml php-xmlreader php-xmlwriter \
        php-session php-net-socket php-mbstring php-gettext php-cli \
        php-mysqlnd php-opcache php-pdo php-snmp php-ldap && \


### PR DESCRIPTION
This resolves an issue where importing templates may incorrectly add quotes around items.

related Zabbix documentation:
https://www.zabbix.com/documentation/3.4/manual/installation/known_issues#compatibility_issue_with_php_70

related ticket:
https://support.zabbix.com/browse/ZBX-12405