### PR TITLE
fix mariadb dump script

### DIFF
--- a/Dockerfile/zabbix-2.4/README.md
+++ b/Dockerfile/zabbix-2.4/README.md
@@ -66,7 +66,7 @@ Examples of admin tasks:
 # Backup of Zabbix configuration data only
 docker exec \
     -ti zabbix-db \
-    /zabbix-backup/zabbix-mariadb-dump -u zabbix -p my_password -o /backups
+    /zabbix-backup/zabbix-dump -u zabbix -p my_password -o /backups
 
 # Full DB backup of Zabbix
 docker exec \

--- a/Dockerfile/zabbix-db-mariadb/Dockerfile
+++ b/Dockerfile/zabbix-db-mariadb/Dockerfile
@@ -21,7 +21,6 @@ RUN \
     yum install -y epel-release && \
     yum install -y MariaDB-server hostname net-tools pwgen git bind-utils bzip2 && \
     git clone https://github.com/maxhq/zabbix-backup && \
-    mv /zabbix-backup/zabbix-mysql-dump /zabbix-backup/zabbix-mariadb-dump && \
     yum autoremove -y git && \
     yum clean all && \
     cp -f -r /tmp/etc/* /etc/ && \

--- a/Dockerfile/zabbix-xxl/README.md
+++ b/Dockerfile/zabbix-xxl/README.md
@@ -66,7 +66,7 @@ Examples of admin tasks:
 # Backup of DB Zabbix - configuration data only, no item history/trends
 docker exec \
     -ti zabbix-db \
-    /zabbix-backup/zabbix-mariadb-dump -u zabbix -p my_password -o /backups
+    /zabbix-backup/zabbix-dump -u zabbix -p my_password -o /backups
 
 # Full backup of Zabbix DB
 docker exec \

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run \
 ## Backup of DB Zabbix - configuration data only, no item history/trends
 docker exec \
     -ti dockbix-db \
-    /zabbix-backup/zabbix-mariadb-dump -u zabbix -p my_password -o /backups
+    /zabbix-backup/zabbix-dump -u zabbix -p my_password -o /backups
 
 ## Full compressed backup of Zabbix DB
 docker exec \


### PR DESCRIPTION
zabbix-mariadb-dump was renamed to zabbix-dump upstream in https://github.com/maxhq/zabbix-backup/commit/2b9506de1da675e740f328e5c2a085be9473408b.
This commit fixes it.